### PR TITLE
Align LL/CON/MAS/BV-23-C with test specification

### DIFF
--- a/src/tests/ll_verification.py
+++ b/src/tests/ll_verification.py
@@ -4096,7 +4096,6 @@ def ll_con_mas_bv_23_c(transport, upperTester, lowerTester, trace):
     success = success and connected;
             
     if connected:
-        success, expectedFeatures = success and readLocalFeatures(transport, upperTester, trace)
         """
             Issue the LE Read Remote Features Command, verify the reception of a Command Status Event
         """
@@ -4108,7 +4107,8 @@ def ll_con_mas_bv_23_c(transport, upperTester, lowerTester, trace):
         success = success and hasFeatures;
         if hasFeatures:
             showLEFeatures(features, trace);
-            success = (toNumber(features) == toNumber(expectedFeatures)) and success;
+            # Bit 27 is "Masked to Peer" an must be cleared
+            success = ((toNumber(features) & (1 << 27)) == 0) and success;
 
         success = initiator.disconnect(0x3E) and success;
     else:


### PR DESCRIPTION
The pass verdict is "All bits in the feature set marked as Masked to
Peer received by the Lower Tester are cleared. The test procedure is
executed successfully, with the IUT responding with the feature
response." Identity between feature sets is not needed for passing.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>