### PR TITLE
Fix some SLA tests to use lowerTester as initiator

### DIFF
--- a/src/tests/ll_verification.py
+++ b/src/tests/ll_verification.py
@@ -2665,7 +2665,7 @@ def ll_con_ini_bv_24_c(transport, upperTester, lowerTester, trace):
 """
 def ll_con_sla_bv_04_c(transport, upperTester, lowerTester, trace):
 
-    advertiser, initiator = setPublicInitiator(transport, upperTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
+    advertiser, initiator = setPublicInitiator(transport, lowerTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
     """
         Obtain maximum Data Packet size and maximum number of Data Packets
     """
@@ -2722,7 +2722,7 @@ def ll_con_sla_bv_04_c(transport, upperTester, lowerTester, trace):
 """
 def ll_con_sla_bv_05_c(transport, upperTester, lowerTester, trace):
 
-    advertiser, initiator = setPublicInitiator(transport, upperTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
+    advertiser, initiator = setPublicInitiator(transport, lowerTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
 
     success = advertiser.enable();
     connected = initiator.connect();
@@ -2759,7 +2759,7 @@ def ll_con_sla_bv_05_c(transport, upperTester, lowerTester, trace):
 """
 def ll_con_sla_bv_06_c(transport, upperTester, lowerTester, trace):
 
-    advertiser, initiator = setPublicInitiator(transport, upperTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
+    advertiser, initiator = setPublicInitiator(transport, lowerTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
 
     success = advertiser.enable();
     connected = initiator.connect();


### PR DESCRIPTION
Fix some SLA tests that used upperTester as initiator, to
use the lowerTester. The issue was noticed when running
two different build configured hci application as IUT and
TST, wherein IUT was a peripheral only controller and TST
was full feature HCI controller. In this case, using the
upperTester as initiator failed, which is incorrect usage
in these tests.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>