### PR TITLE
Fixing address scramble issue, as well as misc. timing related issues

### DIFF
--- a/src/components/advertiser.py
+++ b/src/components/advertiser.py
@@ -102,7 +102,7 @@ class Advertiser:
         self.status = 0;
     
     def __verifyAndShowEvent(self, expectedEvent):
-        event = get_event(self.transport, self.idx, 100);
+        event = get_event(self.transport, self.idx, 200);
         self.trace.trace(7, str(event));
         return event.event == expectedEvent;
 
@@ -121,7 +121,7 @@ class Advertiser:
     def __set_advertise_parameters(self):
 
         self.status = le_set_advertising_parameters(self.transport, self.idx, self.minInterval, self.maxInterval, self.advertiseType, self.ownAddress.type, \
-                                                    self.peerAddress.type, self.peerAddress.address, self.channels, self.filterPolicy, 100);
+                                                    self.peerAddress.type, self.peerAddress.address, self.channels, self.filterPolicy, 200);
         self.trace.trace(6, "LE Set Advertising Parameters Command returns status: 0x%02X" % self.status);
         return self.__getCommandCompleteEvent() and (self.status == 0);
 
@@ -129,7 +129,7 @@ class Advertiser:
 
         dataSize, advertiseData = self.__confined_array(self.advertiseData, 31);
 
-        self.status = le_set_advertising_data(self.transport, self.idx, dataSize, advertiseData, 100);
+        self.status = le_set_advertising_data(self.transport, self.idx, dataSize, advertiseData, 200);
         self.trace.trace(6, "LE Set Advertising Data Command returns status: 0x%02X" % self.status);
         return self.__getCommandCompleteEvent() and (self.status == 0);
 
@@ -137,13 +137,13 @@ class Advertiser:
 
         dataSize, responseData = self.__confined_array(self.responseData, 31);
                 
-        self.status = le_set_scan_response_data(self.transport, self.idx, dataSize, responseData, 100);
+        self.status = le_set_scan_response_data(self.transport, self.idx, dataSize, responseData, 200);
         self.trace.trace(6, "LE Set Scan Response Data Command returns status: 0x%02X" % self.status);
         return self.__getCommandCompleteEvent() and (self.status == 0);
 
     def __advertise_enable(self, enable):
         
-        self.status = le_set_advertising_enable(self.transport, self.idx, enable, 100);
+        self.status = le_set_advertising_enable(self.transport, self.idx, enable, 200);
         self.trace.trace(6, "LE Set Advertising Enable Command (%s) returns status: 0x%02X" % ("Enabling" if enable else "Disabling", self.status));
         return self.__getCommandCompleteEvent() and (self.status == 0);
 
@@ -169,10 +169,10 @@ class Advertiser:
     """
         Check for a advertise timeout - when using connectable high duty cycle directed advertising
     """
-    def timeout(self, timeout=100):
+    def timeout(self, timeout=200):
         self.status = 0;
         if has_event(self.transport, self.idx, timeout)[0]:
-            event = get_event(self.transport, self.idx, 100);
+            event = get_event(self.transport, self.idx, 200);
             self.trace.trace(7, str(event));
             if (event.subEvent == MetaEvents.BT_HCI_EVT_LE_CONN_COMPLETE) or (event.subEvent == MetaEvents.BT_HCI_EVT_LE_ENH_CONN_COMPLETE):
                 self.status = event.decode()[0];

--- a/src/components/basic_commands.py
+++ b/src/components/basic_commands.py
@@ -2810,6 +2810,8 @@ def flush_events(transport, idx, to):
 def has_event(transport, idx, to):
     
     while to >= 0:
+        start_t = transport.last_t
+
         cmd = struct.pack('<HH', Commands.CMD_HAS_EVENT_REQ, 0);
         transport.send(idx, cmd);
         
@@ -2828,11 +2830,12 @@ def has_event(transport, idx, to):
         
         if count > 0:
             break;
-        
+
+        to_tmp = 100 - int((transport.last_t - start_t) / 1000);
         to -= 100;
-        if to >= 0:
-            transport.wait(100);
-        
+        if to >= 0 and to_tmp > 0:
+            transport.wait(to_tmp);
+
     return count > 0, count;
 
 """

--- a/src/components/initiator.py
+++ b/src/components/initiator.py
@@ -81,7 +81,7 @@ class Initiator:
 
         success = has_event(self.transport, idx, timeout)[0];
         if success:
-            event = get_event(self.transport, idx, 100);
+            event = get_event(self.transport, idx, 200);
             self.trace.trace(7, str(event));
             if event.subEvent == MetaEvents.BT_HCI_EVT_LE_CONN_COMPLETE:
                 self.status, handle, role, address, interval, latency, timeout, accuracy = event.decode();
@@ -102,7 +102,7 @@ class Initiator:
 
         success = has_event(self.transport, idx, timeout)[0];
         if success:
-            event = get_event(self.transport, idx, 100);
+            event = get_event(self.transport, idx, 200);
             self.trace.trace(7, str(event));
             if event.event == Events.BT_HCI_EVT_DISCONN_COMPLETE:
                 self.status, handle, reason = event.decode();
@@ -120,7 +120,7 @@ class Initiator:
 
         success = has_event(self.transport, idx, timeout)[0];
         if success:
-            event = get_event(self.transport, idx, 100);
+            event = get_event(self.transport, idx, 200);
             self.trace.trace(7, str(event));
             if event.subEvent == MetaEvents.BT_HCI_EVT_LE_PHY_UPDATE_COMPLETE:
                 self.status, handle, txPhys, rxPhys = event.decode();
@@ -138,7 +138,7 @@ class Initiator:
 
         success = has_event(self.transport, idx, timeout)[0]; 
         while success:
-            event = get_event(self.transport, idx, 100);
+            event = get_event(self.transport, idx, 200);
             self.trace.trace(7, str(event));
             if event.subEvent == MetaEvents.BT_HCI_EVT_LE_CONN_PARAM_REQ:
                 handle, minInterval, maxInterval, latency, supervisionTimeout = event.decode();
@@ -166,7 +166,7 @@ class Initiator:
         else:
             success = has_event(self.transport, idx, timeout)[0];
             if success:
-                event = get_event(self.transport, idx, 100);
+                event = get_event(self.transport, idx, 200);
 
         if success:
             self.trace.trace(7, str(event));
@@ -184,9 +184,9 @@ class Initiator:
         try:
             le_create_connection(self.transport, self.initiator, self.scanInterval, self.scanWindow, self.filterPolicy, self.peerAddress.type, \
                                  self.peerAddress.address, self.initiatorAddress.type, self.intervalMin, self.intervalMax, self.latency, \
-                                 self.supervisionTimeout, self.minCeLen, self.maxCeLen, 100);
+                                 self.supervisionTimeout, self.minCeLen, self.maxCeLen, 200);
 
-            event = get_event(self.transport, self.initiator, 100);
+            event = get_event(self.transport, self.initiator, 200);
             self.trace.trace(7, str(event));
             success = event.isCommandStatus();
             if success:
@@ -205,9 +205,9 @@ class Initiator:
 
         try:
             success = False;
-            disconnect(self.transport, self.initiator, self.handles[0], reason, 100);
-            while has_event(self.transport, self.initiator, 100)[0]:
-                event = get_event(self.transport, self.initiator, 100);
+            disconnect(self.transport, self.initiator, self.handles[0], reason, 200);
+            while has_event(self.transport, self.initiator, 200)[0]:
+                event = get_event(self.transport, self.initiator, 200);
                 self.trace.trace(7, str(event));
                 if event.isCommandStatus():
                     opcode, status = event.decode()[1:];
@@ -227,8 +227,8 @@ class Initiator:
     """
     def __cancel(self):
 
-        status = le_create_connection_cancel(self.transport, self.initiator, 100);
-        event = get_event(self.transport, self.initiator, 100);
+        status = le_create_connection_cancel(self.transport, self.initiator, 200);
+        event = get_event(self.transport, self.initiator, 200);
         self.trace.trace(7, str(event));
         return event.isCommandComplete() and (status == 0);
 
@@ -241,9 +241,9 @@ class Initiator:
             if 4 * timeout <= (1+latency) * maxInterval:
                 timeout = (((1+latency) * maxInterval) + 7) / 4;
 
-            self.status = le_connection_update(self.transport, self.initiator, self.handles[0], minInterval, maxInterval, latency, timeout, self.minCeLen, self.maxCeLen, 100);
+            self.status = le_connection_update(self.transport, self.initiator, self.handles[0], minInterval, maxInterval, latency, timeout, self.minCeLen, self.maxCeLen, 200);
 
-            event = get_event(self.transport, self.initiator, 100);
+            event = get_event(self.transport, self.initiator, 200);
             self.trace.trace(7, str(event));
             success = event.isCommandStatus() and (self.status == 0);
         except Exception as e:
@@ -258,9 +258,9 @@ class Initiator:
     def __updatePhys(self, allPhys, txPhys, rxPhys, optionPhys):
 
         try:
-            self.status = le_set_phy(self.transport, self.initiator, self.handles[0], allPhys, txPhys, rxPhys, optionPhys, 100);
+            self.status = le_set_phy(self.transport, self.initiator, self.handles[0], allPhys, txPhys, rxPhys, optionPhys, 200);
 
-            event = get_event(self.transport, self.initiator, 100);
+            event = get_event(self.transport, self.initiator, 200);
             self.trace.trace(7, str(event));
             success = event.isCommandStatus() and (self.status == 0);
         except Exception as e:
@@ -281,7 +281,7 @@ class Initiator:
                 If Phys has changed - Peer should also receive a LE_PHY_Update_Complete event to signal that the command has been effectuated...
             """
             if not self.peer is None:
-                success, txPhys, rxPhys = self.__hasPhysUpdateCompleteEvent(self.peer, 100);
+                success, txPhys, rxPhys = self.__hasPhysUpdateCompleteEvent(self.peer, 200);
 
         return success;
 
@@ -297,7 +297,7 @@ class Initiator:
         Carry out last part of the connect procedure...
         Wait for (connection complete | enhanced connection complete) events
     """
-    def postConnect(self, timeout=300):
+    def postConnect(self, timeout=600):
         success = self.pre_connected;
         """
             Both initiator and peer can receive a LE Connection Complete Event if connection succeeds...
@@ -336,7 +336,7 @@ class Initiator:
     """
         Carry out the connect procedure...
     """
-    def connect(self, timeout=300):
+    def connect(self, timeout=600):
         success = self.preConnect();
         success = success and self.postConnect(timeout);
         if success:
@@ -353,7 +353,7 @@ class Initiator:
             Both initiator and peer can receive a Disconnection Complete Events...
         """
         if success:
-            initiatorDisconnected, handle, reason = self.__hasDisconnectCompleteEvent(self.initiator, 100 * int((99 + 10 * self.prevInterval) / 100));
+            initiatorDisconnected, handle, reason = self.__hasDisconnectCompleteEvent(self.initiator, 100 * int((99 + 10 * self.prevInterval * 1.25) / 100));
             if initiatorDisconnected:
                 self.handles[0] = -1; self.reasons[0] = reason;
             
@@ -372,7 +372,7 @@ class Initiator:
         if success:
             success = self.__cancel();
             if success:
-                self.__hasConnectionCompleteEvent(self.initiator, 100)[0];
+                self.__hasConnectionCompleteEvent(self.initiator, 200)[0];
 
         return success;
 
@@ -389,7 +389,7 @@ class Initiator:
                 #        Zephyr controller as tester will not generate Connection Parameter Request if it is in Channel Map procedure
                 #        and waiting for instant to pass.
                 self.updPeerRequest, self.cpr_handle, self.cpr_minInterval, self.cpr_maxInterval, self.cpr_latency, self.cpr_timeout = \
-                    self.__hasConnectionParamRequestEvent(self.peer, 100 * int((99 + 10 * self.prevInterval) / 100));
+                    self.__hasConnectionParamRequestEvent(self.peer, 100 * int((99 + 10 * self.prevInterval * 1.25) / 100));
             else:
                 self.updPeerRequest = False;
         return self.updInitiatorRequest;
@@ -407,7 +407,7 @@ class Initiator:
             status, handle = le_remote_connection_parameter_request_reply(self.transport, self.peer, self.cpr_handle, self.cpr_minInterval, self.cpr_maxInterval, \
                                                                           self.cpr_latency, self.cpr_timeout, self.minCeLen, self.maxCeLen, 100);
             success = status == 0;
-            event = get_event(self.transport, self.peer, 100);
+            event = get_event(self.transport, self.peer, 200);
             self.trace.trace(7, str(event));
             success = success and (event.event == Events.BT_HCI_EVT_CMD_COMPLETE);
 
@@ -423,9 +423,9 @@ class Initiator:
             """
                 Send a LL_REJECT_EXT_IND as a reaction to the LE Remote Connection Parameter Request Event...
             """
-            status, handle = le_remote_connection_parameter_request_negative_reply(self.transport, self.peer, self.cpr_handle, reason, 100);
+            status, handle = le_remote_connection_parameter_request_negative_reply(self.transport, self.peer, self.cpr_handle, reason, 200);
             success = status == 0;
-            event = get_event(self.transport, self.peer, 100);
+            event = get_event(self.transport, self.peer, 200);
             self.trace.trace(7, str(event));
             success = success and (event.event == Events.BT_HCI_EVT_CMD_COMPLETE);
 
@@ -443,7 +443,7 @@ class Initiator:
                       Hence wait for 12 intervals before response timeout
             """
             initiatorUpdated, self.status, handle, interval, latency, timeout = \
-                self.__hasConnectionUpdateCompleteEvent(self.initiator, 100 * int((99 + 12 * self.prevInterval) / 100));
+                self.__hasConnectionUpdateCompleteEvent(self.initiator, 100 * int((99 + 12 * self.prevInterval * 1.25) / 100));
             initiatorUpdated = initiatorUpdated and (self.handles[0] == handle);
             if initiatorUpdated:
                 self.intervalMin = self.intervalMax = self.prevInterval = interval;

--- a/src/components/preambles.py
+++ b/src/components/preambles.py
@@ -446,19 +446,19 @@ def preamble_device_address_set(transport, idx, trace):
     Scramble the company_id part of the Bluetooth address.
 """
 def address_scramble_OUI(address):
-    return (address & 0x00ff00ffffff) | ((address << 16) & 0xff0000000000) | ((address >> 16) & 0x0000ff000000);
+    return (address ^ 0xff00ff000000);
 
 """
     Scramble the company_assigned part of the Bluetooth address.
 """
 def address_scramble_LAP(address):
-    return (address & 0xffffff00ff00) | ((address << 16) & 0x000000ff0000) | ((address >> 16) & 0x0000000000ff);
+    return (address ^ 0x000000ff00ff);
 
 """
     Scramble both the company_id part and the company_assigned part of the Bluetooth address.
 """
 def address_exchange_OUI_LAP(address):
-    return (address & 0x00ffffffff00) | ((address << 40) & 0xff0000000000) | ((address >> 40) & 0x0000000000ff);
+    return (address ^ 0xff00000000ff);
 
 def preamble_specific_white_listed(transport, idx, addresses, trace):
     trace.trace(5, "Specific White Listed preamble steps...");

--- a/src/components/scanner.py
+++ b/src/components/scanner.py
@@ -96,7 +96,7 @@ class Scanner:
         self.pivot = 0;
         
     def __verifyAndShowEvent(self, expectedEvent):
-        event = get_event(self.transport, self.idx, 100);
+        event = get_event(self.transport, self.idx, 200);
         self.trace.trace(7, str(event));
         return event.event == expectedEvent;
 
@@ -104,7 +104,7 @@ class Scanner:
         return self.__verifyAndShowEvent(Events.BT_HCI_EVT_CMD_COMPLETE);
     
     def __scan_parameters(self):
-        status = le_set_scan_parameters(self.transport, self.idx, self.scanType, self.scanInterval, self.scanWindow, self.ownAddress.type, self.filterPolicy, 100);
+        status = le_set_scan_parameters(self.transport, self.idx, self.scanType, self.scanInterval, self.scanWindow, self.ownAddress.type, self.filterPolicy, 200);
         self.trace.trace(6, "LE Set Scan Parameters Command returns status: 0x%02X" % status);
         return self.__commandCompleteEvent() and (status == 0);
 
@@ -116,7 +116,7 @@ class Scanner:
         return status == 0;
 
     def clear(self):
-        flush_events(self.transport, self.idx, 100);
+        flush_events(self.transport, self.idx, 200);
 
     """
         Enable scanning...
@@ -140,7 +140,7 @@ class Scanner:
 
     def __handleReport(self, prevTime):
 
-        for event in get_event(self.transport, self.idx, 100, True):
+        for event in get_event(self.transport, self.idx, 200, True):
 
             if event.subEvent == MetaEvents.BT_HCI_EVT_LE_ADVERTISING_REPORT:
 
@@ -174,7 +174,7 @@ class Scanner:
         prevTime = 0;
         while max(self.reports, self.directReports, self.counts/2) < self.expectedReports:
 
-            if has_event(self.transport, self.idx, 100)[0]:
+            if has_event(self.transport, self.idx, 200)[0]:
                 prevTime = self.__handleReport(prevTime);
             else:
                 if self.lastTime == 0:
@@ -187,7 +187,7 @@ class Scanner:
         while (max(self.reports, self.directReports, self.counts/2) < self.expectedReports) or \
               (max(self.responses, self.reports/5, self.counts) < self.expectedResponses):
 
-            if has_event(self.transport, self.idx, 100)[0]:
+            if has_event(self.transport, self.idx, 200)[0]:
                 prevTime = self.__handleReport(prevTime);
             else:
                 if self.lastTime == 0:
@@ -204,7 +204,7 @@ class Scanner:
         prevTime = 0;
         while self.lastTime == 0:
 
-            if has_event(self.transport, self.idx, 99)[0]:
+            if has_event(self.transport, self.idx, 200)[0]:
                 prevTime = self.__handleReport(prevTime);
             else:
                 self.lastTime = prevTime;
@@ -316,8 +316,8 @@ class Scanner:
         if success:
             prevTime = deltaTime = 0;
             while deltaTime < time:
-                if has_event(self.transport, self.idx, 100)[0]:
-                    event = get_event(self.transport, self.idx, 100);
+                if has_event(self.transport, self.idx, 200)[0]:
+                    event = get_event(self.transport, self.idx, 200);
 
                     if event.subEvent == MetaEvents.BT_HCI_EVT_LE_ADVERTISING_REPORT:
                         eventType, address, data, rssi = event.decode();

--- a/src/edttool.py
+++ b/src/edttool.py
@@ -150,10 +150,20 @@ def run_tests(args, xtra_args, transport, trace):
 class Trace():
     def __init__(self, level):
         self.level = level;
+        self.transport = None
 
     def trace(self, level, msg):
         if ( level <= self.level ):
-            print(msg);
+            if self.transport:
+                from datetime import timedelta
+                td = timedelta(microseconds=self.transport.get_last_t())
+                mm, ss = divmod(td.seconds, 60)
+                hh, mm = divmod(mm, 60)
+                ts = "%02d:%02d:%02d.%06d" % (hh, mm, ss, td.microseconds)
+            else:
+                ts = '--:--:--.------'
+            for line in str(msg).split('\n'):
+                print('edtt: @{}  {}'.format(ts, line), flush=True);
 
 def main():
     transport = None;
@@ -165,6 +175,7 @@ def main():
         trace = Trace(args.verbose);
 
         transport = init_transport(args.transport, xtra_args, trace);
+        trace.transport = transport;
 
         result = run_tests(args, xtra_args, transport, trace);
 

--- a/src/tests/ll_verification.py
+++ b/src/tests/ll_verification.py
@@ -597,6 +597,9 @@ def ll_ddi_adv_bv_06_c(transport, upperTester, lowerTester, trace):
         else:
             success = advertiser.disable() and success;
 
+        if not success:
+            break;
+
     return success;
 
 """
@@ -829,7 +832,7 @@ def ll_ddi_adv_bv_11_c(transport, upperTester, lowerTester, trace):
     success = advertiser.timeout() and success;
     success = scanner.disable() and success;
 
-    success = success and scanner.qualifyReportTime( 30, 1280 );
+    success = success and scanner.qualifyReportTime( 30, 1300 );
 
     success = advertiser.enable() and success;
 
@@ -1842,7 +1845,7 @@ def ll_con_adv_bv_04_c(transport, upperTester, lowerTester, trace):
     success = success and connected;
 
     if connected:
-        transport.wait(26630);
+        transport.wait(2660);
 
         success = initiator.disconnect(0x13) and success;
     else:
@@ -1930,6 +1933,7 @@ def ll_con_ini_bv_01_c(transport, upperTester, lowerTester, trace):
 
     advertiser, initiator = setPublicInitiator(transport, upperTester, trace, Advertising.CONNECTABLE_UNDIRECTED);
 
+    success = True;
     for channel in [ AdvertiseChannel.CHANNEL_37, AdvertiseChannel.CHANNEL_38, AdvertiseChannel.CHANNEL_39 ]:
 
         advertiser.channels = channel;
@@ -1938,7 +1942,7 @@ def ll_con_ini_bv_01_c(transport, upperTester, lowerTester, trace):
 
             trace.trace(7, "\nUsing channel %s and Lower Tester address %s\n" % (str(channel), formatAddress(toArray(address, 6))));
 
-            success = preamble_set_public_address(transport, lowerTester, address, trace);
+            success = preamble_set_public_address(transport, lowerTester, address, trace) and success;
             initiator.peerAddress = Address( ExtendedAddressType.PUBLIC, address );
 
             success = initiator.preConnect() and success;
@@ -1959,6 +1963,9 @@ def ll_con_ini_bv_01_c(transport, upperTester, lowerTester, trace):
                 success = initiator.disconnect(0x13) and success;
             else:
                 success = advertiser.disable() and success;
+
+            if not success:
+                break;
 
     return success;
 
@@ -2008,7 +2015,6 @@ def ll_con_ini_bv_06_c(transport, upperTester, lowerTester, trace):
         whiteListAddress = publicIdentityAddress(lowerTester) if j == 0 else randomIdentityAddress(lowerTester);
 
         success = addAddressesToWhiteList(transport, upperTester, [ whiteListAddress ], trace) and success;
-
         addresses = [ Address( ExtendedAddressType.RANDOM if whiteListAddress.type == SimpleAddressType.PUBLIC \
                                                           else ExtendedAddressType.PUBLIC, whiteListAddress.address ),
                       Address( ExtendedAddressType.PUBLIC if whiteListAddress.type == SimpleAddressType.PUBLIC \
@@ -2035,6 +2041,9 @@ def ll_con_ini_bv_06_c(transport, upperTester, lowerTester, trace):
                 """
                 success = initiator.cancelConnect() and success;
                 success = advertiser.disable() and success;
+
+            if not success:
+                break
 
     return success;
 
@@ -4316,6 +4325,7 @@ def ll_con_mas_bv_27_c(transport, upperTester, lowerTester, trace):
             NOTE: We use a little nasty trick here. Swap the roles of initiator and peer and swap assigned handles...
         """
         initiator.switchRoles();
+        transport.wait(20); # FIXME: Avoid test failure due to Zephyr controller occasionally generating Different Transaction Collision
         """
             Lower tester requests an update of the connection parameters - sends an LL_CONNECTION_PARAM_REQ...
         """


### PR DESCRIPTION
It has been seen for a while, that changing the order of the LL-tests could make quite a number of tests fail now and again.
During debugging of this, I found the below mentioned error in the address scrambling as well as the error in the has_event util function.

Address scramble utils fixed - previous version swapped bytes in
address to create new address, this fails if bytes are identical

has_event util timeout handling was incorrect - waited longer. Now
the timeout is correct. However this then calls for the general update
to timeouts.

Added formatted timing info to trace-out
