### PR TITLE
Added support for ISO EDTT/HCI commands and ISO HCI events

### DIFF
--- a/src/components/basic_commands.py
+++ b/src/components/basic_commands.py
@@ -405,6 +405,8 @@ class MetaEvents(IntEnum):
     BT_HCI_EVT_LE_ADV_SET_TERMINATED        = 18
     BT_HCI_EVT_LE_SCAN_REQ_RECEIVED         = 19
     BT_HCI_EVT_LE_CHAN_SEL_ALGO             = 20
+    BT_HCI_EVT_LE_CIS_ESTABLISHED           = 25
+    BT_HCI_EVT_LE_CIS_REQUEST               = 26
 
 def echo(transport, idx, message, to):
     


### PR DESCRIPTION
The following ISO HCI events have been added:
- BT_HCI_EVT_LE_CIS_ESTABLISHED
- BT_HCI_EVT_LE_CIS_REQUEST
 
The following ISO HCI commands have been added:
- le_set_cig_parameters
- le_set_cig_parameters_test
- le_create_cis
- le_remove_cig
- le_accept_cis_request
- le_reject_cis_request
- le_setup_iso_data_path
- le_remove_iso_data_path
- le_set_host_feature

The following ISO EDTT commands have been added:
- le_iso_data_flush
- le_iso_data_ready
- le_iso_data_write
- le_iso_data_read

Signed-off-by: Morten Priess <mtpr@oticon.com>