### PR TITLE
ial: Uncomment passing test cases

### DIFF
--- a/src/tests/ial_verification.py
+++ b/src/tests/ial_verification.py
@@ -1190,8 +1190,8 @@ __tests__ = {
     "IAL/CIS/FRA/PER/BV-26-C": [ial_cis_fra_per_bv_26_c, "Send Single SDU, CIS"],
     "IAL/CIS/UNF/PER/BV-47-C": [ial_cis_unf_per_bv_47_c, "Send Single SDU, CIS"],
     "IAL/CIS/FRA/PER/BV-45-C": [ial_cis_fra_per_bv_45_c, "Send Single SDU, CIS"],
-    # "IAL/CIS/UNF/PER/BV-04-C": [ial_cis_unf_per_bv_04_c, "Send Large SDU, CIS"],  # Failed to create CIG
-    # "IAL/CIS/UNF/PER/BV-28-C": [ial_cis_unf_per_bv_28_c, "Send Large SDU, CIS"],  # Failed to create CIG
+    "IAL/CIS/UNF/PER/BV-04-C": [ial_cis_unf_per_bv_04_c, "Send Large SDU, CIS"],
+    "IAL/CIS/UNF/PER/BV-28-C": [ial_cis_unf_per_bv_28_c, "Send Large SDU, CIS"],
     "IAL/CIS/FRA/PER/BV-05-C": [ial_cis_fra_per_bv_05_c, "Send Large SDU, CIS"],
     "IAL/CIS/FRA/PER/BV-29-C": [ial_cis_fra_per_bv_29_c, "Send Large SDU, CIS"],
     "IAL/CIS/FRA/PER/BV-46-C": [ial_cis_fra_per_bv_46_c, "Send Large SDU, CIS"],


### PR DESCRIPTION
After recent fixes in out reference controller, those 2 test cases
are passing now.

edtt: @00:00:00.490000  IAL/CIS/UNF/PER/BV-04-C [Send Large SDU, CIS]
test started...
edtt: @00:00:02.000000  IAL/CIS/UNF/PER/BV-04-C [Send Large SDU, CIS]
PASSED
edtt: @00:00:02.480000  IAL/CIS/UNF/PER/BV-28-C [Send Large SDU, CIS]
test started...
edtt: @00:00:04.090000  IAL/CIS/UNF/PER/BV-28-C [Send Large SDU, CIS]
PASSED
edtt: @00:00:04.090000
edtt: @00:00:04.090000  Summary:
edtt: @00:00:04.090000
edtt: @00:00:04.090000  Status   Count
edtt: @00:00:04.090000  ==============
edtt: @00:00:04.090000  PASS         2
edtt: @00:00:04.090000  ==============
edtt: @00:00:04.090000  Total        2

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>