### PR TITLE
Add LL/CON/ADV/BV-14-C and LL/CON/ADV/BV-15-C test cases

### DIFF
--- a/src/components/preambles.py
+++ b/src/components/preambles.py
@@ -557,7 +557,7 @@ def preamble_ext_advertise_enable(transport, idx, enable, SHandle, SDuration, SM
     trace.trace(5, "Extended Advertising " + ("Enable" if enable else "Disable") + " preamble steps...");
 
     try:
-        NumberOfSets = max(len(sHandle), len(SDuration), len(SMaxExtAdvEvts));
+        NumberOfSets = max(len(SHandle), len(SDuration), len(SMaxExtAdvEvts));
         if len(SHandle) < NumberOfSets:
             SHandle += [ 0 for _ in range(len(SHandle), NumberOfSets) ];
         if len(SDuration) < NumberOfSets:


### PR DESCRIPTION
Added the two test cases

Updated PacketDecoder to support a lot more packets and added a flush() to clear out any existing packets when looping inside a test case

Updated Initiator to support connecting via extended commands

Signed-off-by: Troels Nilsson <trnn@demant.com>