### PR TITLE
Add LL/CON/ADV/BV-05-C and LL/CON/ADV/BV-12-C test cases

### DIFF
--- a/src/components/basic_commands.py
+++ b/src/components/basic_commands.py
@@ -2669,7 +2669,9 @@ def le_set_extended_scan_enable(transport, idx, enable, FilterDup, duration, per
 """
 def le_extended_create_connection(transport, idx, FilterPolicy, OwnAddrType, PeerAddrType, AVal, phys, PInterval, PWindow, PConnIntervalMin, PConnIntervalMax, PConnLatency, PSupervisionTimeout, PMinCeLen, PMaxCeLen, to):
 
-    cmd = struct.pack('<HHHBBB6BB' + 'HHHHHHHH' * phys, Commands.CMD_LE_EXTENDED_CREATE_CONNECTION_REQ, 12 + 16 * phys,
+    PHYCount = bin(phys).count("1")
+
+    cmd = struct.pack('<HHHBBB6BB' + 'HHHHHHHH' * PHYCount, Commands.CMD_LE_EXTENDED_CREATE_CONNECTION_REQ, 12 + 16 * PHYCount,
                       HCICommands.BT_HCI_OP_LE_EXT_CREATE_CONN, FilterPolicy, OwnAddrType, PeerAddrType, *AVal, phys,
                       *list(chain(*list(zip(PInterval, PWindow, PConnIntervalMin, PConnIntervalMax, PConnLatency, PSupervisionTimeout, PMinCeLen, PMaxCeLen)))))
 


### PR DESCRIPTION
Added tests for LL/CON/ADV/BV-05-C and LL/CON/ADV/BV-12-C; Note that the implementation is only partial, since we cannot control the contents of AUX_CONNECT_REQ directly

Fixed le_extended_create_connection() commands handling of non-1M phys

Signed-off-by: Troels Nilsson <trnn@demant.com>