### PR TITLE
Add LL/DDI/ADV/BV-47-C and LL/DDI/ADV/BV-49-C test cases

### DIFF
--- a/src/components/events.py
+++ b/src/components/events.py
@@ -1223,7 +1223,8 @@ class Event:
         if self.__checkSize(6):
             status, advertiseHandle, connectionHandle, completedEvents = struct.unpack('<BBHB', self.data[1:6]);
             self.__checkAdvertisingHandle(advertiseHandle);
-            self.__checkConnectionHandle(connectionHandle);
+            if status == 0:
+                self.__checkConnectionHandle(connectionHandle)
         else:
             status = advertiseHandle = connectionHandle = completedEvents = 0;
         return status, advertiseHandle, connectionHandle, completedEvents;


### PR DESCRIPTION
Added the two (very similar) test cases

Updated packet trace decoding, so extended advertisement packets will now have a pointer to its superior packet(s)

Fixed decoding of the LE Advertising Set Terminated event when advertising has stopped to some other cause than a new connection

Signed-off-by: Troels Nilsson [trnn@demant.com](mailto:trnn@demant.com)