### PR TITLE
Add LL/DDI/ADV/BV-28-C test case

### DIFF
--- a/src/components/dump.py
+++ b/src/components/dump.py
@@ -617,5 +617,7 @@ class Packets:
             return None
     
     def flush(self):
+        for dump in self.__dumps.fetch():
+            pass
         self.__parser = PacketParser()
         self.__packets = []


### PR DESCRIPTION
Adds the LL/DDI/ADV/BV-28-C test case

Fix packets.flush not flushing packets that are still unread

Signed-off-by: Troels Nilsson [trnn@demant.com](mailto:trnn@demant.com)