### PR TITLE
Fix race when opening BSim dump files

### DIFF
--- a/src/components/edttt_bsim.py
+++ b/src/components/edttt_bsim.py
@@ -87,6 +87,11 @@ class EDTTT:
         packet = self.read(2);
         self.n_devices = struct.unpack('<H',packet[0:2])[0];
 
+        # Wait for dump files to have been opened by the 2G4 phy
+        # Since there isn't a method implemented for synchronizing that, use the fact that any commands to the 2G4 phy will not
+        # run until after it has opened the files for writing; So use a minimal wait as a blocking mechanism
+        self.wait_until_t(1)
+
     def cleanup(self):
         if self.low_level_device:
             self.Trace.trace(4,"Cleaning up low-level device");


### PR DESCRIPTION
Python would on rare occasions try to open the files before the 2G4 phy had opened/created them, causing weird errors

Fixed by blocking the transports connect() until the phy has been confirmed to be ready

Signed-off-by: Troels Nilsson <trnn@demant.com>