### PR TITLE
bsim transport: Use WAIT_WRESP insteado of WAIT

### DIFF
--- a/docs/EDTT_transport_bsim.md
+++ b/docs/EDTT_transport_bsim.md
@@ -73,8 +73,8 @@ This is done by having the EDTT command the bridge to either:
           simulation time to advance by `<recv_wait_us>`, and try again.
           (`<recv_wait_us>` is a bridge command line option, by default 10ms)
     * If the bridge is commanded to wait, it will wait for the simulation time to
-      advance to the requested time and reply with a dummy byte (with a value of 0)
-      to indicate that the wait is done
+      advance to the requested time and, if the wait requested a response, reply
+      with a dummy byte (with a value of 0) to indicate that the wait is done
 
 3. The embedded device transport
 
@@ -150,7 +150,8 @@ The protocol with the EDTTool is as follows:
        1 byte : reception done (0) or timeout (1)
        8 bytes: timestamp when the reception or timeout actually happened
        0/N bytes: (0 bytes if timeout, N bytes as requested otherwise)
-   to a WAIT:  1 byte (0) when wait is done
+   to a WAIT: nothing
+   to a WAIT_WRESP: 1 byte (0) when wait is done
    to a DISCONNECT: nothing
 ```
 


### PR DESCRIPTION
Use the new WAIT_WRESP command to the EDTT bridge instead of the November modified WAIT when expecting a reply for a wait command.

The change in the WAIT command functionality
broke backwards compatibility with the EDTT bridge (and backwards compatibility from the newer bridge to older EDTT version).
The bridge has now been fixed to avoid the backwards compatibility issue with older (prior to Nov/23,
18744c937131104797ea0abf0dcfc84855a12311
) versions of the EDTT, but this means the WAIT
command no longer responds. Instead we need to use the new WAIT_WRESP command.

Also check the response, if we get a UNKNOWN_COMMAND (or anything !=0), we warn the user about the too old EDTT instead of crashing badly.

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>