### PR TITLE
GATT Database: Remove auth signed write property

### DIFF
--- a/src/components/GATT Database.xml
+++ b/src/components/GATT Database.xml
@@ -36,7 +36,7 @@
 						</Descriptors>
 					</Characteristic>
 					<Characteristic uuid="2B29" name="Client Features" handle="5" properties="10" permissions="3">00</Characteristic>
-					<Characteristic uuid="2B2A" name="Attribute Database Hash" handle="7" properties="2" permissions="1">F6 5E 40 DE 41 00 7C BC 88 71 E8 F3 06 B9 E0 26</Characteristic>
+					<Characteristic uuid="2B2A" name="Attribute Database Hash" handle="7" properties="2" permissions="1">83 32 CF 5D 12 79 10 C0 34 33 E1 2B E7 35 C5 B9</Characteristic>
 				</Characteristics>
 			</Service>
 			<Service type="Primary Service" uuid="1800" name="Generic Access Profile" handle="9">
@@ -176,7 +176,7 @@
 							<Descriptor uuid="2905" name="Aggregate Format" handle="175" permissions="1">A6 00 A9 00 AC 00</Descriptor>
 						</Descriptors>
 					</Characteristic>
-					<Characteristic uuid="B011" name="Value V17" handle="176" properties="66" permissions="3">12</Characteristic>
+					<Characteristic uuid="B011" name="Value V17" handle="176" properties="2" permissions="3">12</Characteristic>
 				</Characteristics>
 			</Service>
 			<Service type="Primary Service" uuid="0000A00C000000000123456789ABCDEF" name="Service C.2" handle="192">


### PR DESCRIPTION
This commit removes Authenticated Signed Write property from a characteristic and updates GATT Database hash.

The property is removed as the Data signing support is deprecated in Zephyr Bluetooth Host. See corresponding PR for Zephyr.

Affected tests:
GATT/SR/GPA/BV-04-C
GATT/SR/GAR/BV-04-C
GATT/SR/GAD/BV-04-C
GATT/SR/GAD/BV-05-C